### PR TITLE
Semgrep

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,18 @@
+name: Semgrep
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  semgrep:
+    name: Semgrep SAST
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      - uses: actions/checkout@v3
+      - run: semgrep ci
+        env:
+           SEMGREP_RULES: auto

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @Tolam-Earth/armm-developers will be requested for
+# review when someone opens a pull request.
+
+* @Tolam-Earth/tolam-oci-integration-owners
+
+.github/ @Tolam-Earth/tolam-oci-cloud-owners
+cloudbuild* @Tolam-Earth/tolam-oci-cloud-owners
+SECURITY.md @Tolam-Earth/tolam-oci-security-owners


### PR DESCRIPTION
## Proposed changes

Implement Semgrep to scan source code for vulnerabilities. For now, use default rules, but we will tailor the rule sets later.

- Semgrep scans source code via GitHub Actions on pushes and pull requests
- Create `CODEOWNERS` file
